### PR TITLE
Remove transitive dependencies and force output to `main.js`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources" "target"]
- :deps {com.bhauman/figwheel-main {:mvn/version "0.2.12"}
-        hodur/engine            {:mvn/version "0.1.8"}
+ :deps {#_com.bhauman/figwheel-main #_{:mvn/version "0.2.12"}
+        #_hodur/engine            #_{:mvn/version "0.1.8"}
         hodur/visualizer-schema {:mvn/version "0.1.1"}}}
-        ;persistent-sorted-set/persistent-sorted-set {:mvn/version "0.1.2"}}}
+                                        ;persistent-sorted-set/persistent-sorted-set {:mvn/version "0.1.2"}}}

--- a/src/bare/build.clj
+++ b/src/bare/build.clj
@@ -4,5 +4,5 @@
 (defn -main [main]
   (fig/start {:id "dev"
               :options {:main main
-                        :output-to "target/public/cljs-out/dev-main.js"}
+                        :output-to "target/public/cljs-out/main.js"}
               :config {:watch-dirs ["src"]}}))


### PR DESCRIPTION
Both figwheel and hodur engine are transitive dependencies of hodur visualizer so, in practice, you don't need to depend on them directly.

I don't think these deps caused any problem in your case but I removed them to make sure visualizer was running with the versions it depended on.

The key change was the `fig/start` call that was pointing to `dev-main.js` instead.

Also, an annoying step (due to licensing issues) that always escapes me when kicking off new projects is this one (from the README):

```
$ mkdir -p resources/public/scripts
$ curl https://gojs.net/latest/release/go.js -o resources/public/scripts/go.js
```

It is also recommended that you list `resources/public/scripts/go.js` out of your SCM (i.e. GitHub) to avoid legal issues.